### PR TITLE
Update to PHP 8.4 in Dockerfile and relax Composer PHP version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+## 0.1.1
+### Added
+- Change php version requirements — [#44](https://github.com/mesilov/bitrix24-php-lib/pull/44)
+
+## 0.1.0
+
+### By [@mesilov](https://github.com/mesilov)
+- Add initial project setup with CI configuration — [#2](https://github.com/mesilov/bitrix24-php-lib/pull/2)
+- Fix incorrect annotation syntax from `#[\Override]` to `#[Override]` — [#3](https://github.com/mesilov/bitrix24-php-lib/pull/3)
+- Rename package and namespaces to `bitrix24-php-lib` — [#4](https://github.com/mesilov/bitrix24-php-lib/pull/4)
+- Add docker structure — [#13](https://github.com/mesilov/bitrix24-php-lib/pull/13)
+- Add application install — [#43](https://github.com/mesilov/bitrix24-php-lib/pull/43)
+
+---
+
+### By [@KarlsonComplete](https://github.com/KarlsonComplete)
+- Add docker containers — [#12](https://github.com/mesilov/bitrix24-php-lib/pull/12)
+- Add docker structure —  [#14](https://github.com/mesilov/bitrix24-php-lib/pull/14), [#15](https://github.com/mesilov/bitrix24-php-lib/pull/15),   [#16](https://github.com/mesilov/bitrix24-php-lib/pull/16), [#17](https://github.com/mesilov/bitrix24-php-lib/pull/17),  [#19](https://github.com/mesilov/bitrix24-php-lib/pull/19), [#27](https://github.com/mesilov/bitrix24-php-lib/pull/27),   [#29](https://github.com/mesilov/bitrix24-php-lib/pull/29), [#32](https://github.com/mesilov/bitrix24-php-lib/pull/32),   [#34](https://github.com/mesilov/bitrix24-php-lib/pull/34), [#36](https://github.com/mesilov/bitrix24-php-lib/pull/36),   [#37](https://github.com/mesilov/bitrix24-php-lib/pull/37),  [#38](https://github.com/mesilov/bitrix24-php-lib/pull/38)
+- Added mapping, fixing functional tests — [#18](https://github.com/mesilov/bitrix24-php-lib/pull/18)
+- Removed attributes in the account — [#20](https://github.com/mesilov/bitrix24-php-lib/pull/20)
+- Fixed some errors in functional tests — [#21](https://github.com/mesilov/bitrix24-php-lib/pull/21)
+- Added fetcher test and removed more comments — [#22](https://github.com/mesilov/bitrix24-php-lib/pull/22)
+- Fixes — [#23](https://github.com/mesilov/bitrix24-php-lib/pull/23)
+- Fixes for scope — [#24](https://github.com/mesilov/bitrix24-php-lib/pull/24)
+- Update fetcher and flusher — [#25](https://github.com/mesilov/bitrix24-php-lib/pull/25)
+- Add application install — [#40](https://github.com/mesilov/bitrix24-php-lib/pull/40)  

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     }
   },
   "require": {
-    "php": "8.3.*",
+    "php": "^8.3",
     "ext-json": "*",
     "ext-curl": "*",
     "ext-bcmath": "*",

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli-alpine
+FROM php:8.4-cli-alpine
 
 RUN apk add unzip libpq-dev git icu-dev autoconf build-base linux-headers \
     && docker-php-ext-install bcmath pdo pdo_pgsql intl \


### PR DESCRIPTION
…aints

This commit updates the PHP base image in the `php-cli` Dockerfile from `8.3` to `8.4`. Additionally, the PHP version requirement in `composer.json` is changed from `8.3.*` to `^8.3`, allowing for better compatibility with future minor PHP releases. The `CHANGELOG.md` is also updated to reflect these changes.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes/no                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #44  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | MIT                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->