### PR TITLE
Fix journal table namespacing and add repository maintainer skill

### DIFF
--- a/.claude/skills/bitrix24-php-lib-maintainer/SKILL.md
+++ b/.claude/skills/bitrix24-php-lib-maintainer/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: bitrix24-php-lib-maintainer
+description: |
+  Use this skill whenever working with GitHub issues or maintainer workflows in the mesilov/bitrix24-php-lib repository:
+  reading or creating issues, planning implementation from an issue, choosing the correct base branch,
+  updating CHANGELOG.md, or preparing a pull request that follows the repository template and quality gate.
+  Use the bitrix24-dev MCP server when issue context depends on official Bitrix24 documentation.
+user-invocable: true
+allowed-tools: Bash, mcp__github__issue_read, mcp__github__issue_write, mcp__github__search_issues, mcp__github__pull_request_read, mcp__github__create_pull_request, mcp__github__list_commits, mcp__bitrix24_dev__bitrix_search, mcp__bitrix24_dev__bitrix_method_details, mcp__bitrix24_dev__bitrix_article_details, mcp__bitrix24_dev__bitrix_event_details, mcp__bitrix24_dev__bitrix_app_development_doc_details
+---
+
+# bitrix24-php-lib Maintainer
+
+Repository: **mesilov/bitrix24-php-lib** (`owner: mesilov`, `repo: bitrix24-php-lib`)
+
+---
+
+## On skill invocation: verify project MCP and repo workflow
+
+Before doing issue-driven work, confirm the repository-level setup:
+
+1. `.mcp.json` exists in the repository root.
+2. `.mcp.json` contains the `bitrix24-dev` server:
+
+```json
+{
+  "mcpServers": {
+    "bitrix24-dev": {
+      "type": "http",
+      "url": "https://mcp-dev.bitrix24.tech/mcp"
+    }
+  }
+}
+```
+
+3. The MCP server is available in the current client.
+4. If `.mcp.json` changed after the last pull, restart the client before continuing.
+
+Project rule: run linters and tests only through `Makefile` entrypoints. Do not call tool binaries directly when an equivalent `make` target exists.
+
+Primary quality commands:
+
+```bash
+make lint-all
+make test-unit
+make test-functional
+```
+
+Autofix commands are allowed only when an autofix pass is explicitly needed:
+
+```bash
+make lint-cs-fixer-fix
+make lint-rector-fix
+```
+
+---
+
+## Working with an existing issue
+
+When given an issue number, load it first via GitHub tools and read:
+
+- title
+- body
+- labels
+- linked discussion or acceptance criteria
+
+Do not start implementation from a short user summary if the issue already contains the authoritative scope.
+
+If the issue affects Bitrix24 install flow, auth flow, lifecycle events, or SDK-backed contracts, expand context from official Bitrix24 documentation through the `bitrix24-dev` MCP server before planning the change.
+
+Useful MCP tools:
+
+| Tool | When to use |
+|---|---|
+| `mcp__bitrix24_dev__bitrix_search` | when the exact method, event, or article name is unknown |
+| `mcp__bitrix24_dev__bitrix_method_details` | when the change depends on a specific REST method |
+| `mcp__bitrix24_dev__bitrix_event_details` | when the issue is about `ONAPPINSTALL`, lifecycle hooks, or event semantics |
+| `mcp__bitrix24_dev__bitrix_article_details` | when you need overview or concept documentation |
+| `mcp__bitrix24_dev__bitrix_app_development_doc_details` | when the issue touches app-development rules or platform behavior |
+
+Record the relevant findings in the implementation plan so the plan is grounded in current documentation, not memory.
+
+---
+
+## GitHub CLI fallback
+
+When GitHub MCP tools are unavailable or return auth errors, use `gh` via `Bash`:
+
+```bash
+gh search issues "<query>" --repo mesilov/bitrix24-php-lib --state open
+gh label list --repo mesilov/bitrix24-php-lib
+gh issue view <number> --repo mesilov/bitrix24-php-lib
+gh issue create --repo mesilov/bitrix24-php-lib --title "..." --body "..."
+gh pr create --repo mesilov/bitrix24-php-lib --title "..." --body "..." --base <branch>
+```
+
+Use the CLI only as a fallback, not as the first choice when MCP tools work.
+
+---
+
+## Creating a new issue
+
+Before creating a new issue:
+
+1. Search for duplicates in `mesilov/bitrix24-php-lib`.
+2. Verify the exact label names in the repository before applying them.
+3. Write the issue so that another maintainer can implement it without guesswork.
+
+Recommended issue body structure:
+
+```markdown
+## Problem
+
+<What is broken, missing, or unclear?>
+
+## Proposed solution
+
+<What should be changed and where?>
+
+## Acceptance criteria
+
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] <criterion 3>
+```
+
+Title rules:
+
+- Feature: `Add <feature description>`
+- Bug fix: `Fix <what is broken>`
+- Refactoring: `Refactor <what and why>`
+- Documentation: `Document <topic>`
+
+Keep the title concrete. Avoid vague titles such as `Fix tests` or `Improve code`.
+
+---
+
+## Project conventions for implementation work
+
+### Source layout
+
+Main bounded contexts in this repository:
+
+- `ApplicationInstallations`
+- `ApplicationSettings`
+- `Bitrix24Accounts`
+- `ContactPersons`
+- `Journal`
+
+Typical code layout:
+
+```text
+src/<BoundedContext>/
+    Docs/
+    Entity/
+    Infrastructure/
+    Services/
+    UseCase/
+tests/Unit/<BoundedContext>/
+tests/Functional/<BoundedContext>/
+tests/Helpers/
+```
+
+Follow the existing bounded-context structure. Do not introduce a new folder pattern when the current context already has an established one.
+
+### Branch naming
+
+Use:
+
+```text
+feature/<issue-number>-<short-slug>
+bugfix/<issue-number>-<short-slug>
+```
+
+Examples from the repository:
+
+- `feature/99-bump-dependencies`
+- `bugfix/90-fix-app-install`
+
+### Base branch
+
+Default rule:
+
+- branch from `dev` for regular issue work
+- use `main` only for release or hotfix work when that target is explicit
+
+If the correct base branch is unclear from the issue context, ask before branching. Do not guess.
+
+### Commit messages
+
+Use an imperative subject line that says what changed:
+
+```text
+Fix install flow for tokenless UI installs
+Add functional coverage for duplicate ONAPPINSTALL handling
+Update README with MCP and Makefile workflow
+```
+
+When the change is tied to a specific issue, include the issue reference if it improves traceability.
+Do not use Conventional Commits unless the repository starts using them explicitly.
+
+---
+
+## Task folder and implementation plan
+
+This repository already uses `.tasks/<issue-number>/` for implementation planning.
+
+Before writing production code for an issue:
+
+1. Create or reuse `.tasks/<issue-number>/`.
+2. Create a plan file named:
+
+```text
+.tasks/<issue-number>/<short-slug>-plan.md
+```
+
+Examples already in the repository:
+
+- `.tasks/90/install-handler-status-fix-plan.md`
+- `.tasks/93/table-names-normalization-plan.md`
+
+Recommended plan structure:
+
+```markdown
+## Summary
+
+<What problem is being solved and why?>
+
+## Scope
+
+<What is in scope and what is explicitly out of scope?>
+
+## Target contract
+
+<Expected behavior after the change>
+
+## Implementation changes
+
+1. <file / module / rule to change>
+2. <tests to update>
+3. <docs or changelog to update>
+
+## Test cases and scenarios
+
+1. <unit scenarios>
+2. <functional scenarios>
+
+## Assumptions and defaults
+
+<Any decisions that must stay explicit>
+```
+
+Plan rules:
+
+- use exact file paths when possible
+- name the concrete classes, handlers, commands, repositories, or docs involved
+- include verification steps before coding starts
+- present the plan to the user and wait for explicit approval before production edits
+
+---
+
+## Start-of-work protocol for implementing an issue
+
+When the user asks to implement an issue, follow this order:
+
+### Step 1 — Load the issue
+
+Read the full issue first.
+
+### Step 2 — Expand external context when needed
+
+If the issue depends on Bitrix24 platform behavior, contracts, events, or official docs, fetch the relevant documentation through `bitrix24-dev`.
+
+### Step 3 — Choose the base branch
+
+Use `dev` by default for normal development work. Use `main` only for explicit hotfix or release work.
+
+### Step 4 — Create the working branch
+
+Use `feature/<issue-number>-<slug>` or `bugfix/<issue-number>-<slug>`.
+
+### Step 5 — Create the task plan
+
+Write `.tasks/<issue-number>/<slug>-plan.md` before production changes.
+
+### Step 6 — Review the plan
+
+Check the plan for:
+
+- unambiguity
+- internal consistency
+- full coverage of tests and docs
+
+### Step 7 — Get approval
+
+Show the plan and wait for explicit approval before editing production code.
+
+### Step 8 — Implement and verify
+
+Work from the approved plan, updating it if scope changes.
+
+---
+
+## Testing and quality gate
+
+For code changes, run checks in this order:
+
+```bash
+make lint-all
+make test-unit
+make test-functional
+```
+
+Rules:
+
+- Use only `make` targets, never direct binary calls.
+- If `make lint-all` fails, fix the root cause before moving to tests.
+- If `make test-unit` fails, fix that before running `make test-functional`.
+- Do not skip failing tests or comment them out to get green output.
+- For docs-only or metadata-only changes, tests may be skipped, but the final report must say that explicitly.
+
+When a formatter or automated refactor is needed, use:
+
+```bash
+make lint-cs-fixer-fix
+make lint-rector-fix
+```
+
+Then rerun the full quality gate.
+
+---
+
+## CHANGELOG.md rules
+
+The repository does not use an `Unreleased` section by default. Do not invent one.
+
+Before changing `CHANGELOG.md`:
+
+1. Read the current top section.
+2. Preserve the existing style and heading structure.
+3. Add release-note entries only when the change is user-visible, release-relevant, or explicitly requested.
+
+Typical cases that should update `CHANGELOG.md`:
+
+- new features
+- deprecations or BC changes
+- externally visible bug fixes
+- developer workflow changes that affect contributors
+
+When issue references exist, prefer linking them in the same style already used in the file.
+
+---
+
+## Pull request workflow
+
+After the quality gate is green:
+
+### Step 1 — Re-read the PR template from disk
+
+Always read:
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+Do not use a memorized PR body.
+
+### Step 2 — Fill the template exactly
+
+Respect the existing table fields:
+
+- `Bug fix?`
+- `New feature?`
+- `Deprecations?`
+- `Issues`
+- `License`
+
+When the PR closes an issue, use the repository convention from the template:
+
+```text
+Fix #<issue-number>
+```
+
+### Step 3 — Summarize verification honestly
+
+List which commands were run and whether they passed:
+
+- `make lint-all`
+- `make test-unit`
+- `make test-functional`
+
+If some checks were intentionally skipped, state exactly why.
+
+### Step 4 — Create the PR against the correct base branch
+
+Use the same base branch that was chosen at branch creation time.
+
+### Step 5 — Return the PR URL
+
+After creation, return the PR URL to the user.
+
+---
+
+## Maintainer mindset for this repository
+
+- All work is organized through issues.
+- Think and discuss first, then write code.
+- Prefer bounded-context consistency over one-off shortcuts.
+- Reuse existing builders, helpers, and repository patterns in tests.
+- When documentation or workflow rules already exist in `README.md`, `AGENTS.md`, or `.tasks/`, align with them instead of inventing a parallel process.

--- a/.tasks/102/journal-table-prefix-plan.md
+++ b/.tasks/102/journal-table-prefix-plan.md
@@ -1,0 +1,37 @@
+## План по issue #102: префикс `b24lib_` для journal table
+
+### Summary
+Issue `#102` описывает несогласованность Doctrine mapping для `Bitrix24\Lib\Journal\Entity\JournalItem`: таблица `journal` не была переведена на namespaced-нейминг `b24lib_*`, хотя остальные entity tables уже были нормализованы в рамках issue `#93`.
+
+Целевое состояние:
+- таблица journal хранится в `b24lib_journal`;
+- явно именованные индексы journal используют тот же префикс;
+- документация и changelog не оставляют старые имена актуальными.
+
+### Scope
+- зафиксировать `table="b24lib_journal"` в `config/xml/Bitrix24.Lib.Journal.Entity.JournalItem.dcm.xml`;
+- переименовать явно заданные journal indexes в `b24lib_journal_*`;
+- обновить `src/Journal/Docs/README.md`, где таблица и индексы названы текстом;
+- добавить upgrade note в `CHANGELOG.md` как breaking change для существующих установок, уже создавших таблицу `journal`.
+
+### Out of Scope
+- автоматические миграции внутри библиотеки;
+- изменение доменной модели, PHP API и repository-контрактов;
+- переименование колонок или структуры journal payload/context.
+
+### Test Cases and Verification
+1. `make test-unit`
+- unit suite остаётся зелёным после изменения mapping-сопровождения и документации.
+
+2. `make test-functional`
+- Doctrine продолжает успешно поднимать схему с `b24lib_journal`;
+- functional suite остаётся зелёным без ссылок на старые имена journal schema objects.
+
+3. Документационная проверка
+- `src/Journal/Docs/README.md` показывает актуальные имена `b24lib_journal` и `b24lib_journal_*`;
+- `CHANGELOG.md` содержит явный upgrade path `journal -> b24lib_journal` и переименование индексов.
+
+### Assumptions
+- source of truth по схеме: XML mapping в `config/xml`;
+- для issue `#102` принимается singular table name `b24lib_journal`, потому что именно это имя уже используется в текущем change set и оно согласовано с issue body как допустимый вариант;
+- миграцию существующей БД выполняет потребитель библиотеки вручную перед обновлением.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,21 @@
 # AGENTS
 
+## Local Skills
+
+This repository contains local workflow skills in `.claude/skills/`.
+
+Before starting issue-driven, maintainer, or repository workflow tasks, agents must:
+
+- check whether `.claude/skills/**/SKILL.md` exists
+- load and follow the relevant local skill before relying on generic built-in skills
+- treat repository-local skills as higher priority than generic platform skills when both apply
+
+Default local maintainer skill for this repository:
+
+- `.claude/skills/bitrix24-php-lib-maintainer/SKILL.md`
+
+If a local skill defines a stricter workflow than `AGENTS.md`, follow the local skill.
+
 ## MCP Servers
 
 This repository includes project-level MCP server configuration in `.mcp.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## 0.5.1
 
+### BC
+
+- **Journal table namespacing fix** — [#102](https://github.com/mesilov/bitrix24-php-lib/issues/102)
+    - Table renamed:
+        - `journal` -> `b24lib_journal`
+    - Explicit schema object names renamed:
+        - `idx_journal_composite` -> `b24lib_journal_idx_composite`
+        - `idx_journal_created_at` -> `b24lib_journal_idx_created_at`
+        - `idx_journal_member_id` -> `b24lib_journal_idx_member_id`
+    - Existing PostgreSQL installations created from `0.5.0` must rename the existing journal table and indexes before the first run on `0.5.1`
+    - Example SQL:
+```sql
+ALTER TABLE journal RENAME TO b24lib_journal;
+
+ALTER INDEX idx_journal_composite RENAME TO b24lib_journal_idx_composite;
+ALTER INDEX idx_journal_created_at RENAME TO b24lib_journal_idx_created_at;
+ALTER INDEX idx_journal_member_id RENAME TO b24lib_journal_idx_member_id;
+```
+
 ### Changed
 
 - **Dependency refresh for PHP 8.5 and current QA toolchain**
@@ -11,6 +30,9 @@
     - Narrowed install/account handler internals with explicit assertions and intersection types for aggregate roots that emit domain events
     - Added explicit callback parameter types in `ApplicationSettingsListCommand`
     - Removed deprecated `strictBooleans` prepared set from `rector.php`
+- **Repository-local maintainer workflow for agents**
+    - Added `.claude/skills/bitrix24-php-lib-maintainer/SKILL.md` as the default local skill for issue-driven and maintainer tasks
+    - Documented local-skill precedence and project MCP checks in `AGENTS.md` and `CLAUDE.md`
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Claude Code Knowledge Base - bitrix24-php-lib
 
+## Local Skills
+- Repository-local skills live in `.claude/skills/`.
+- Before starting issue-driven, maintainer, or repository workflow tasks, always check whether `.claude/skills/**/SKILL.md` exists and load the relevant local skill first.
+- When both a local repository skill and a generic built-in skill apply, prefer the local repository skill.
+- Default maintainer workflow for this repository: `.claude/skills/bitrix24-php-lib-maintainer/SKILL.md`.
+- If a local skill defines a stricter workflow than this file, follow the local skill.
+
 ## Project Overview
 PHP library for rapid Bitrix24 application development using PostgreSQL and Doctrine ORM.
 

--- a/config/xml/Bitrix24.Lib.Journal.Entity.JournalItem.dcm.xml
+++ b/config/xml/Bitrix24.Lib.Journal.Entity.JournalItem.dcm.xml
@@ -1,7 +1,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:xs="https://www.w3.org/2001/XMLSchema"
                   xmlns:orm="https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <entity name="Bitrix24\Lib\Journal\Entity\JournalItem" table="journal">
+    <entity name="Bitrix24\Lib\Journal\Entity\JournalItem" table="b24lib_journal">
         <id name="id" type="uuid" column="id">
 
         </id>
@@ -21,9 +21,9 @@
         <embedded name="context" class="Bitrix24\Lib\Journal\Entity\ValueObjects\Context"/>
 
         <indexes>
-            <index name="idx_journal_composite" columns="member_id,application_installation_id,level,created_at_utc"/>
-            <index name="idx_journal_created_at" columns="created_at_utc"/>
-            <index name="idx_journal_member_id" columns="member_id"/>
+            <index name="b24lib_journal_idx_composite" columns="member_id,application_installation_id,level,created_at_utc"/>
+            <index name="b24lib_journal_idx_created_at" columns="created_at_utc"/>
+            <index name="b24lib_journal_idx_member_id" columns="member_id"/>
         </indexes>
     </entity>
 </doctrine-mapping>

--- a/src/Journal/Docs/README.md
+++ b/src/Journal/Docs/README.md
@@ -187,7 +187,7 @@ class MyTest extends TestCase
 
 ## Database Schema
 
-Таблица `journal_item` с полями:
+Таблица `b24lib_journal` с полями:
 - `id` (UUID) - PK
 - `member_id` (string) - ID портала Bitrix24
 - `application_installation_id` (UUID) - FK к установке приложения
@@ -198,10 +198,10 @@ class MyTest extends TestCase
 - `payload`, `bitrix24_user_id`, `ip_address` - поля контекста
 
 ### Индексы
-- `idx_journal_composite (member_id, application_installation_id, level, created_at_utc)`  
+- `b24lib_journal_idx_composite (member_id, application_installation_id, level, created_at_utc)`  
   Используется эффективно по левому префиксу:
     - `member_id`
     - `member_id + application_installation_id`
     - `member_id + application_installation_id + level`
-- `idx_journal_member_id (member_id)`
-- `idx_journal_created_at (created_at_utc)`
+- `b24lib_journal_idx_member_id (member_id)`
+- `b24lib_journal_idx_created_at (created_at_utc)`


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | yes |
| New feature?  | yes |
| Deprecations? | no |
| Issues        | Fix #102 |
| License       | MIT |

This PR fixes the remaining journal schema naming inconsistency by renaming the Doctrine table mapping from `journal` to `b24lib_journal` and aligning explicitly named journal indexes with the same namespace prefix.

It also updates the journal documentation and changelog with the required breaking-change upgrade note for existing PostgreSQL installations.

Additionally, this PR adds a repository-local maintainer skill in `.claude/skills/bitrix24-php-lib-maintainer/SKILL.md` and documents its usage in `AGENTS.md` and `CLAUDE.md` so issue-driven agent workflows follow the project-specific MCP and Makefile rules.

Validation performed:
- `make test-unit`
- `make test-functional`
- `make lint-all`