### PR TITLE
Allow DoctrineBundle 3.3 for Symfony 8 compatibility

### DIFF
--- a/.tasks/106/symfony8-doctrine-bundle-plan.md
+++ b/.tasks/106/symfony8-doctrine-bundle-plan.md
@@ -1,0 +1,36 @@
+## План по issue #106
+
+### Summary
+
+Issue `#106` требует убрать Symfony 8 boot blocker в consumer applications,
+обновив root constraint `doctrine/doctrine-bundle` с `3.2.2` до линии `3.3`.
+
+Проблема уже подтверждена вне библиотеки: с текущим constraint consumer app на
+Symfony `8.0.*` падает на bootstrap, а с временным override до
+`doctrine/doctrine-bundle:^3.3` успешно проходит `composer update`,
+`php bin/console cache:clear` и HTTP boot.
+
+### Scope
+
+- обновить dependency constraint в `composer.json` до installable варианта для текущего состояния Packagist;
+- зафиксировать Symfony 8 compatibility в `CHANGELOG.md`;
+- прогнать repository-local verification только через `Makefile`;
+- проверить, что change set не требует дополнительных library-local code changes.
+
+### Non-goals
+
+- не перепроектировать интеграцию Doctrine или Symfony в runtime-коде библиотеки;
+- не добавлять ad hoc test commands вне `Makefile`;
+- не эмулировать внешний consumer app внутри этого репозитория.
+
+### Acceptance Mapping
+
+1. `composer.json` требует `doctrine/doctrine-bundle:^3.2.2 || ^3.3@dev`, так как на момент работы стабильный `3.3` ещё отсутствует на Packagist, а чистый `^3.3` неразрешим при `minimum-stability: stable`.
+2. CHANGELOG явно фиксирует, что следующий релиз снимает Symfony 8 boot blocker.
+3. Library-local quality gate не показывает регрессии на актуальной среде проекта.
+
+### Verification
+
+- `make test-unit`
+- при доступной среде: `make test-functional`
+- при необходимости: `make lint-all`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.3
+
+### Changed
+
+- **Symfony 8 boot compatibility for consumer applications** — [#106](https://github.com/mesilov/bitrix24-php-lib/issues/106)
+    - Relaxed `doctrine/doctrine-bundle` from `3.2.2` to `^3.2.2 || ^3.3@dev`
+    - Keeps stable installs on `3.2.2` while allowing Symfony 8 consumer applications to opt into the `3.3.x-dev` line
+    - Documents explicit compatibility with Symfony `8.0.*` consumer applications
+    - Removes the previously observed Doctrine bundle bootstrap blocker during kernel boot
+
 ## 0.5.2
 
 ### BC

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "bitrix24/b24phpsdk": "dev-v3-dev",
     "darsyn/ip": "^6",
     "darsyn/ip-doctrine": "^6",
-    "doctrine/doctrine-bundle": "3.2.2",
+    "doctrine/doctrine-bundle": "^3.2.2 || ^3.3@dev",
     "doctrine/doctrine-migrations-bundle": "4.0.0",
     "doctrine/orm": "^3",
     "fig/http-message-util": "^1",


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | yes |
| New feature?  | no |
| Deprecations? | no |
| Issues        | Fix #106 |
| License       | MIT |

This PR updates the Doctrine bundle constraint to unblock Symfony 8 consumer applications while keeping the package installable under the repository's current `minimum-stability: stable` setting.

Implemented change:
- `doctrine/doctrine-bundle`: `3.2.2` -> `^3.2.2 || ^3.3@dev`

Why not plain `^3.3`:
- Composer currently resolves only `3.3.x-dev` for the DoctrineBundle 3.3 line
- a plain `^3.3` constraint is not installable here because stable `3.3` is not available yet
- the mixed constraint preserves stable installs on `3.2.2` and allows Symfony 8 consumer apps to opt into the validated `3.3.x-dev` line

Also included:
- `CHANGELOG.md` entry for the next release documenting Symfony 8 compatibility
- issue plan in `.tasks/106/`

Verification:
- `make test-unit`
- `make test-functional`
- `make composer "update doctrine/doctrine-bundle --dry-run"`